### PR TITLE
add convinience methods for putValue()

### DIFF
--- a/typed-values/src/main/java/org/camunda/bpm/engine/variable/Variables.java
+++ b/typed-values/src/main/java/org/camunda/bpm/engine/variable/Variables.java
@@ -138,6 +138,14 @@ public class Variables {
     }
   }
 
+  public static VariableMap putValue(String name, Object value) {
+    return createVariables().putValue(name, value);
+  }
+
+  public static VariableMap putValueTyped(String name, TypedValue value) {
+    return createVariables().putValueTyped(name, value);
+  }
+
   public static ObjectValueBuilder objectValue(Object value) {
     return new ObjectVariableBuilderImpl(value);
   }

--- a/typed-values/src/test/java/org/camunda/bpm/engine/test/api/variable/VariableApiTest.java
+++ b/typed-values/src/test/java/org/camunda/bpm/engine/test/api/variable/VariableApiTest.java
@@ -68,6 +68,15 @@ public class VariableApiTest {
   }
 
   @Test
+  public void testVariableMapWithoutCreateVariables() {
+    VariableMap map1 = putValue("foo", true).putValue("bar", 20);
+    VariableMap map2 = putValueTyped("foo", booleanValue(true)).putValue("bar", integerValue(20));
+
+    assertEquals(map1, map2);
+    assertTrue(map1.values().containsAll(map2.values()));
+  }
+
+  @Test
   public void testVariableMapCompatibility() {
 
     // test compatibility with Map<String, Object>


### PR DESCRIPTION
I'd prefer to start setting variables directly. With this PR you can use

Variables.putValue(key, value)   in addition to Variables.createVariables().putValue(key,value)

which is (imo) shorter and more readble.