### PR TITLE
CAM-10923: chore(commons): move logging rule classes to commons

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -36,6 +36,12 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.camunda.commons</groupId>
+        <artifactId>camunda-commons-testing</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <module>logging</module>
     <module>utils</module>
     <module>typed-values</module>
+    <module>testing</module>
   </modules>
 
   <properties>

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,22 @@
+#camunda commons Testing
+
+This project provides utility classes for Testing that are used in several Camunda projects
+
+## Usage of the `ProcessEngineLoggingRule` class
+
+1. Add a public field to the test class with type `ProcessEngineLoggingRule`
+  * Optionally, provide the logger names of the loggers to watch for through `ProcessEngineLoggingRule#watch`
+  * Optionally, provide the log level to watch for through `ProcessEngineLoggingRule#level`
+2. Annotate the field with the `@Rule` annotation. E.g.:
+```java
+@Rule
+public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule();
+```
+3. Optionally, annotate the desired test cases with the `@WatchLogger` annotation. E.g.:
+```java
+@Test
+@WatchLogger(loggerNames = {LIST_OF_LOGGER_NAMES}, level = "LOG_LEVEL")
+public void testOverrideWithAnnotation() {
+
+}
+```

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.camunda.commons</groupId>
+    <artifactId>camunda-commons-root</artifactId>
+    <version>1.7.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camunda-commons-testing</artifactId>
+  <name>camunda Commons - Testing</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+
+    <!-- TEST -->
+    <dependency>
+      <groupId>org.camunda.commons</groupId>
+      <artifactId>camunda-commons-logging</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/testing/src/main/java/org/camunda/commons/testing/LogEventComparator.java
+++ b/testing/src/main/java/org/camunda/commons/testing/LogEventComparator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.commons.testing;
+
+import java.util.Comparator;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class LogEventComparator implements Comparator<ILoggingEvent> {
+
+  @Override
+  public int compare(ILoggingEvent o1, ILoggingEvent o2) {
+    // cast should be safe as MAX_INT miliseconds are ~25 days
+    return (int) (o1.getTimeStamp() - o2.getTimeStamp());
+  }
+
+}

--- a/testing/src/main/java/org/camunda/commons/testing/ProcessEngineLoggingRule.java
+++ b/testing/src/main/java/org/camunda/commons/testing/ProcessEngineLoggingRule.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.commons.testing;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+public class ProcessEngineLoggingRule extends TestWatcher {
+
+  public static final String LOGGER_NOT_FOUND_ERROR = "no logger found with name ";
+  public static final String NOT_WATCHING_ERROR = "not watching any logger with name: ";
+  private static final String APPENDER_NAME = "defaultAppender";
+
+  Map<String, Logger> globallyWatched = new HashMap<>();
+  Level globalLevel = Level.DEBUG;
+
+  Map<String, Logger> allWatched = new HashMap<>();
+
+  public ProcessEngineLoggingRule watch(String... loggerName) {
+    for (String logger : loggerName) {
+      watch(logger, null);
+    }
+    return this;
+  }
+
+  public ProcessEngineLoggingRule watch(String loggerName, Level level) {
+    Logger logger = getLogger(loggerName);
+    logger.setLevel(level);
+    globallyWatched.put(logger.getName(), logger);
+    return this;
+  }
+
+  public ProcessEngineLoggingRule level(Level level) {
+    globalLevel = level;
+    return this;
+  }
+
+  private Logger getLogger(String loggerName) {
+    Logger logger;
+    try {
+      logger = (Logger) LoggerFactory.getLogger(loggerName);
+      if(logger.getLevel() == null || globalLevel.isGreaterOrEqual(logger.getLevel())) {
+        logger.setLevel(globalLevel);
+      }
+    } catch (ClassCastException e) {
+      throw new RuntimeException(LOGGER_NOT_FOUND_ERROR + loggerName);
+    }
+    return logger;
+  }
+
+  public List<ILoggingEvent> getLog(String loggerName) {
+    Logger logger = allWatched.get(loggerName);
+    if (logger == null) {
+      throw new RuntimeException(NOT_WATCHING_ERROR + loggerName);
+    }
+    return ((ListAppender<ILoggingEvent>) logger.getAppender(APPENDER_NAME)).list;
+  }
+
+  public List<ILoggingEvent> getLog() {
+    List<ILoggingEvent> allLogs = new ArrayList<>();
+    for (String loggerName : allWatched.keySet()) {
+      allLogs.addAll(getLog(loggerName));
+    }
+    Collections.sort(allLogs, new LogEventComparator());
+    return allLogs;
+  }
+
+  public List<ILoggingEvent> getFilteredLog(String subString){
+    List<ILoggingEvent> log = getLog();
+    return filterLog(log, subString);
+  }
+
+  public List<ILoggingEvent> getFilteredLog(String loggerName, String subString) {
+    List<ILoggingEvent> log = getLog(loggerName);
+    return filterLog(log, subString);
+  }
+
+  @Override
+  protected void starting(Description description) {
+    Map<String, Logger> toWatch = new HashMap<>(globallyWatched);
+    WatchLogger watchLoggerAnnotation = description.getAnnotation(WatchLogger.class);
+    if (watchLoggerAnnotation != null) {
+      Level level = Level.toLevel(watchLoggerAnnotation.level());
+      if (level == null) {
+        level = globalLevel;
+      }
+      for (String loggerName : watchLoggerAnnotation.loggerNames()) {
+        Logger logger = getLogger(loggerName);
+        logger.setLevel(level);
+        toWatch.put(loggerName, logger);
+      }
+    }
+    watchLoggers(toWatch);
+  }
+
+  @Override
+  protected void finished(Description description) {
+    // reset logback configuration
+    for (Logger logger : allWatched.values()) {
+      logger.detachAppender(APPENDER_NAME);
+      logger.setLevel(null);
+    }
+  }
+
+  private void watchLoggers(Map<String, Logger> loggers) {
+    for (Entry<String, Logger> loggerEntry : loggers.entrySet()) {
+      ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+      listAppender.setName(APPENDER_NAME);
+      listAppender.start();
+      Logger logger = loggerEntry.getValue();
+      if(logger.getLevel() == null) {
+        logger.setLevel(globalLevel);
+      }
+      logger.addAppender(listAppender);
+      allWatched.put(loggerEntry.getKey(), logger);
+    }
+  }
+
+  private List<ILoggingEvent> filterLog(List<ILoggingEvent> log, String subString){
+    List<ILoggingEvent> filteredLog = new ArrayList<>();
+    for (ILoggingEvent logEntry : log) {
+      if(logEntry.getFormattedMessage().contains(subString)) {
+        filteredLog.add(logEntry);
+      }
+    }
+    return filteredLog;
+  }
+}

--- a/testing/src/main/java/org/camunda/commons/testing/WatchLogger.java
+++ b/testing/src/main/java/org/camunda/commons/testing/WatchLogger.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.commons.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WatchLogger {
+
+  String[] loggerNames() default {};
+  
+  String level();
+}

--- a/testing/src/test/java/org/camunda/commons/testing/ProcessEngineLoggingRuleTest.java
+++ b/testing/src/test/java/org/camunda/commons/testing/ProcessEngineLoggingRuleTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.commons.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.List;
+
+import org.camunda.commons.testing.util.ExampleProcessEngineLogger;
+import org.junit.Rule;
+import org.junit.Test;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+@SuppressWarnings("unused")
+public class ProcessEngineLoggingRuleTest {
+
+  private static final String PERSISTENCE_LOGGER = "org.camunda.bpm.engine.persistence"; // 03
+  private static final String CONTAINER_INTEGRATION_LOGGER = "org.camunda.bpm.container"; //08
+  private static final String PROCESS_APPLICATION_LOGGER = "org.camunda.bpm.application"; //07
+  private static final String JOB_EXECUTOR_LOGGER = "org.camunda.bpm.engine.jobexecutor"; //14
+
+  @Rule
+  public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule()
+                                                      .watch(PERSISTENCE_LOGGER, CONTAINER_INTEGRATION_LOGGER)
+                                                        .level(Level.DEBUG)
+                                                      .watch(PROCESS_APPLICATION_LOGGER, Level.INFO);
+
+  @Test
+  public void testWithoutAnnotation() {
+    // given
+
+    // when
+    logSomethingOnAllLevels();
+
+    List<ILoggingEvent> persistenceLog = loggingRule.getLog(PERSISTENCE_LOGGER);
+    List<ILoggingEvent> containerLog = loggingRule.getLog(CONTAINER_INTEGRATION_LOGGER);
+    List<ILoggingEvent> processAppLogger = loggingRule.getLog(PROCESS_APPLICATION_LOGGER);
+    RuntimeException expectedException = null;
+    try {
+      List<ILoggingEvent> jobExecutorLogger = loggingRule.getLog(JOB_EXECUTOR_LOGGER);
+    } catch (RuntimeException e) {
+      expectedException = e;
+    }
+
+    // then
+    assertThat(expectedException).isNotNull();
+    assertThat(expectedException.getMessage()).contains(ProcessEngineLoggingRule.NOT_WATCHING_ERROR);
+    testLogLevel(persistenceLog, Level.DEBUG);
+    testLogLevel(containerLog, Level.DEBUG);
+    testLogLevel(processAppLogger, Level.INFO);
+  }
+
+  @Test
+  @WatchLogger(loggerNames = {CONTAINER_INTEGRATION_LOGGER}, level = "WARN")
+  public void testOverrideWithAnnotation() {
+    // given
+
+    // when
+    logSomethingOnAllLevels();
+
+    List<ILoggingEvent> persistenceLog = loggingRule.getLog(PERSISTENCE_LOGGER);
+    List<ILoggingEvent> containerLog = loggingRule.getLog(CONTAINER_INTEGRATION_LOGGER);
+    List<ILoggingEvent> processAppLogger = loggingRule.getLog(PROCESS_APPLICATION_LOGGER);
+    RuntimeException expectedException = null;
+    try {
+      List<ILoggingEvent> jobExecutorLogger = loggingRule.getLog(JOB_EXECUTOR_LOGGER);
+    } catch (RuntimeException e) {
+      expectedException = e;
+    }
+
+    // then
+    assertThat(expectedException).isNotNull();
+    assertThat(expectedException.getMessage()).contains(ProcessEngineLoggingRule.NOT_WATCHING_ERROR);
+    testLogLevel(persistenceLog, Level.DEBUG);
+    testLogLevel(containerLog, Level.WARN);
+    testLogLevel(processAppLogger, Level.INFO);
+  }
+  
+  @Test
+  @WatchLogger(loggerNames = {JOB_EXECUTOR_LOGGER}, level = "ERROR")
+  public void testAddWatchedLoggerWithAnnotation() {
+    // given
+
+    // when
+    logSomethingOnAllLevels();
+
+    List<ILoggingEvent> persistenceLog = loggingRule.getLog(PERSISTENCE_LOGGER);
+    List<ILoggingEvent> containerLog = loggingRule.getLog(CONTAINER_INTEGRATION_LOGGER);
+    List<ILoggingEvent> processAppLogger = loggingRule.getLog(PROCESS_APPLICATION_LOGGER);
+    List<ILoggingEvent> jobExecutorLogger = loggingRule.getLog(JOB_EXECUTOR_LOGGER);
+
+    // then
+    testLogLevel(persistenceLog, Level.DEBUG);
+    testLogLevel(containerLog, Level.DEBUG);
+    testLogLevel(processAppLogger, Level.INFO);
+    testLogLevel(jobExecutorLogger, Level.ERROR);
+  }
+  
+  @Test
+  @WatchLogger(loggerNames = {CONTAINER_INTEGRATION_LOGGER}, level = "OFF")
+  public void testTurnOffWatcherWithAnnotation() {
+    // given
+
+    // when
+    logSomethingOnAllLevels();
+
+    
+    List<ILoggingEvent> persistenceLog = loggingRule.getLog(PERSISTENCE_LOGGER);
+    List<ILoggingEvent> containerLog = loggingRule.getLog(CONTAINER_INTEGRATION_LOGGER);
+    List<ILoggingEvent> processAppLogger = loggingRule.getLog(PROCESS_APPLICATION_LOGGER);
+    RuntimeException expectedException = null;
+    try {
+      List<ILoggingEvent> jobExecutorLogger = loggingRule.getLog(JOB_EXECUTOR_LOGGER);
+    } catch (RuntimeException e) {
+      expectedException = e;
+    }
+
+    // then
+    assertThat(expectedException).isNotNull();
+    assertThat(expectedException.getMessage()).contains(ProcessEngineLoggingRule.NOT_WATCHING_ERROR);
+    testLogLevel(persistenceLog, Level.DEBUG);
+    testLogLevel(processAppLogger, Level.INFO);
+    assertThat(containerLog.size()).isEqualTo(0);
+  }
+
+  @Test
+  @WatchLogger(loggerNames = {JOB_EXECUTOR_LOGGER, PERSISTENCE_LOGGER, CONTAINER_INTEGRATION_LOGGER, PROCESS_APPLICATION_LOGGER}, level = "DEBUG")
+  public void testLogOrder() {
+    logSomethingOnAllLevels();
+
+    List<ILoggingEvent> fullLog = loggingRule.getLog();
+    ILoggingEvent previousLogEntry = null;
+    for (ILoggingEvent logEntry : fullLog) {
+      if(previousLogEntry != null) {
+        assertThat(previousLogEntry.getTimeStamp() <= logEntry.getTimeStamp()).isTrue();
+      }
+      previousLogEntry = logEntry;
+    }
+  }
+
+  private void testLogLevel(List<ILoggingEvent> log, Level level) {
+    testAtLeastOneLogEntryWithLevelIsPresent(log, level);
+    testAllLoggingEntriesAtLeastLevel(log, level);
+  }
+
+  private void testAtLeastOneLogEntryWithLevelIsPresent(List<ILoggingEvent> log, Level level) {
+    for (ILoggingEvent logEntry : log) {
+      if(logEntry.getLevel().equals(level)) {
+        return;
+      }
+    }
+    fail("Expected at least one log entry with level " + level + " in log");
+  }
+  
+  private void testAllLoggingEntriesAtLeastLevel(List<ILoggingEvent> log, Level level) {
+    for (ILoggingEvent logStatement : log) {
+      assertThat(logStatement.getLevel().isGreaterOrEqual(level)).isTrue();
+    }
+  }
+  
+  public void logSomethingOnAllLevels() {
+    ExampleProcessEngineLogger.PERSISTENCE_LOGGER.debug(); 
+    ExampleProcessEngineLogger.PERSISTENCE_LOGGER.info(); 
+    ExampleProcessEngineLogger.PERSISTENCE_LOGGER.warn(); 
+    ExampleProcessEngineLogger.PERSISTENCE_LOGGER.error(); 
+
+    ExampleProcessEngineLogger.CONTAINER_INTEGRATION_LOGGER.debug(); 
+    ExampleProcessEngineLogger.CONTAINER_INTEGRATION_LOGGER.info(); 
+    ExampleProcessEngineLogger.CONTAINER_INTEGRATION_LOGGER.warn();
+    ExampleProcessEngineLogger.CONTAINER_INTEGRATION_LOGGER.error(); 
+
+    ExampleProcessEngineLogger.JOB_EXECUTOR_LOGGER.debug(); 
+    ExampleProcessEngineLogger.JOB_EXECUTOR_LOGGER.info(); 
+    ExampleProcessEngineLogger.JOB_EXECUTOR_LOGGER.warn(); 
+    ExampleProcessEngineLogger.JOB_EXECUTOR_LOGGER.error(); 
+
+    ExampleProcessEngineLogger.PROCESS_APPLICATION_LOGGER.debug(); 
+    ExampleProcessEngineLogger.PROCESS_APPLICATION_LOGGER.info(); 
+    ExampleProcessEngineLogger.PROCESS_APPLICATION_LOGGER.warn();
+    ExampleProcessEngineLogger.PROCESS_APPLICATION_LOGGER.error();
+  }
+}

--- a/testing/src/test/java/org/camunda/commons/testing/util/ExampleProcessEngineLogger.java
+++ b/testing/src/test/java/org/camunda/commons/testing/util/ExampleProcessEngineLogger.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.commons.testing.util;
+
+import org.camunda.commons.logging.BaseLogger;
+
+public class ExampleProcessEngineLogger extends BaseLogger {
+  public static final String PROJECT_CODE = "ENGINE";
+
+  public static final ExampleProcessEngineLogger PERSISTENCE_LOGGER = BaseLogger.createLogger(
+      ExampleProcessEngineLogger.class, PROJECT_CODE, "org.camunda.bpm.engine.persistence", "03");
+
+  public static final ExampleProcessEngineLogger CONTAINER_INTEGRATION_LOGGER = BaseLogger.createLogger(
+      ExampleProcessEngineLogger.class, PROJECT_CODE, "org.camunda.bpm.container", "08");
+
+  public static final ExampleProcessEngineLogger JOB_EXECUTOR_LOGGER = BaseLogger.createLogger(
+      ExampleProcessEngineLogger.class, PROJECT_CODE, "org.camunda.bpm.engine.jobexecutor", "14");
+
+  public static final ExampleProcessEngineLogger PROCESS_APPLICATION_LOGGER = BaseLogger.createLogger(
+      ExampleProcessEngineLogger.class, PROJECT_CODE, "org.camunda.bpm.application", "07");
+
+  public void info() {
+    logInfo("01", "This is an INFO log in component {}}!", this.componentId);
+  }
+
+  public void debug() {
+    logDebug("02", "This is a DEBUG log in component {}}!", this.componentId);
+  }
+
+  public void warn() {
+    logWarn("03", "This is a WARN log in component {}}!", this.componentId);
+  }
+
+  public void error() {
+    logError("04", "This is an ERROR log in component {}}!", this.componentId);
+  }
+}


### PR DESCRIPTION
* Move the {{ProcessEngineLoggingRule}} and it's related classes to a separate Camunda Commons module (Testing);
* Move the related test cases;
* Add a readme for the new module where the Rule usage is described.

Related to [CAM-10923](https://app.camunda.com/jira/browse/CAM-10923)